### PR TITLE
add support for credentails from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,26 @@ This repository provides an example of how to create a dashboard that pulls stat
 ```
 cd acirb/examples/acidashboard
 ```
-- Modify jobs/apic.erb to include your APIC IP address and credentials with an account that can query the objects being polled
+- Modify jobs/apic.rb to include your APIC IP address and credentials with an account that can query the objects being polled
 ```
 apicuri = 'https://apic'
 username = 'admin'
 password = 'password'
 ```
-
+- As an alternative you can use the according env vars
+```
+export ACI_APICURI='https://apic'
+export ACI_USERNAME='admin'
+export ACI_PASSWORD='password'
+```
 # Running
 - Start the Docker Container
 ```
 docker run -v=/local/path/to/aci-dashboard/jobs:/jobs -v=/local/path/to/aci-dashboard/widgets:/widgets -v=/local/path/to/aci-dashboard/dashboards:/dashboards -d -e GEMS=acirb -p 3030:3030 frvi/dashing
+```
+- or with env vars
+```
+docker run -v=/local/path/to/aci-dashboard/jobs:/jobs -v=/local/path/to/aci-dashboard/widgets:/widgets -v=/local/path/to/aci-dashboard/dashboards:/dashboards -d -e GEMS=acirb -e ACI_APICURI='https://apic' -e ACI_USERNAME='admin' -e ACI_PASSWORD='password' -p 3030:3030 frvi/dashing
 ```
 - Wait a couple minutes and access your local web server at http://DASHBOARD-SERVER-IP:3030
 - If the container does not have IP access to the APIC, the container will automatically quit.  

--- a/jobs/apic.rb
+++ b/jobs/apic.rb
@@ -16,9 +16,9 @@
 require 'acirb'
 require 'time'
 
-apicuri = 'https://apic'
-username = 'admin'
-password = 'password'
+apicuri = ENV['ACI_APICURI'] || 'https://apic'
+username = ENV['ACI_USERNAME'] || 'admin'
+password = ENV['ACI_PASSWORD'] || 'password'
 
 login_time = Time.new.to_f
 puts 'Connecting to APIC %s' % apicuri


### PR DESCRIPTION
Hey guys we wanted to test-run this app in our kubernetes cluster and it would make things much easier to use if we could fetch the credentials from environment variables. This would help to allow users to run this app without prior code changes and the requirement to build the docker container by themselves.